### PR TITLE
fix placeholder override typo

### DIFF
--- a/src/components/Chat/Chat.jsx
+++ b/src/components/Chat/Chat.jsx
@@ -127,7 +127,7 @@ const Chat = ({
 
   let placeholder = "Write your message here";
   if (placeholderText) {
-    placeHolder = placeholderText;
+    placeholder = placeholderText;
   }
 
   return (


### PR DESCRIPTION
Hey,

I'm currently using your bot in a personal project and almost literally saved my entire year. Thing is, I was trying to override the header and placehold like in #7 and blew up. After a little search i found this:

```
  let placeholder = "Write your message here";
  if (placeholderText) {
    placeHolder = placeholderText;
  }
```
So anyways, I just wanted to help you fix it as a small thank you for the awesome work!

Keep it up man

Handwave-with-social-distancing 
