### PR TITLE
update ts-loader regex to avoid build errors

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.tsx?|.jsx?|.js?|.ts?$/,
+        test: /\.tsx?|\.jsx?|\.js?|\.ts?$/,
         use: 'ts-loader',
         exclude: /node_modules/,
       },


### PR DESCRIPTION
this caused builds on my Windows 11 dev env to blow up as it was processing CSS and SVG files