### PR TITLE
pass bot state into ActionProvider Component

### DIFF
--- a/src/components/Chatbot/Chatbot.tsx
+++ b/src/components/Chatbot/Chatbot.tsx
@@ -101,6 +101,7 @@ const Chatbot = ({
   } else {
     return (
       <ActionProvider
+        state={state}
         setState={setState}
         createChatBotMessage={createChatBotMessage}
       >


### PR DESCRIPTION
any state set inside of bot config will now be passed into ActionProvider. This is helpful for examples like:
- Bot responses are fetched from a backend and need to pass a backend id param in the ActionProvider step that is only known at runtime.